### PR TITLE
[FEATURE] 올리브영 상품 데이터 크롤링

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+beautifulsoup4==4.12.3
+pandas==2.2.1
+selenium==4.18.1
+webdriver-manager==4.0.1
+lxml==5.2.1
+urllib3<2

--- a/src/parser_prd.py
+++ b/src/parser_prd.py
@@ -1,0 +1,90 @@
+import os
+from bs4 import BeautifulSoup
+import json
+import pandas as pd
+import re
+
+def extract_products_from_html(html):
+    soup = BeautifulSoup(html, "html.parser")
+    prd_infos = soup.select("div.prd_info")
+    results = []
+
+    for prd in prd_infos:
+        try:
+            name = prd.select_one(".tx_name").get_text(strip=True)
+            brand = prd.select_one(".tx_brand").get_text(strip=True) if prd.select_one(".tx_brand") else None
+            link = prd.select_one("a")["href"]
+            image = prd.select_one("img")["src"] if prd.select_one("img") else None
+
+            raw_p = prd.select_one(".tx_org .tx_num")
+            raw_price = raw_p.get_text(strip=True).replace(",", "") if raw_p else None
+
+            sale_p = prd.select_one(".tx_cur .tx_num")
+            sale_price = sale_p.get_text(strip=True).replace(",", "") if sale_p else None
+
+            score_tag = prd.select_one(".review_point .point")
+            score = None
+
+            if score_tag:
+                style = score_tag.get("style", "")  # 스타일 값이 ""어도 안전하게 처리
+                if "width" in style:
+                    try:
+                        percent_str = style.replace("width:", "").replace("%", "").strip()
+                        percent = float(percent_str) if percent_str else None
+
+                        if percent is not None:
+                            score = round(percent / 20, 2)
+                    except:
+                        score = None
+
+
+            review_tag = prd.select_one(".prd_point_area")
+            review_count = None
+            if review_tag:
+                text = review_tag.get_text(strip=True)  # 10점만점에 5.5점(999+)
+                m = re.search(r"\(([\d\+]+)\)", text)   # 괄호 안 숫자만 추출
+                review_count = m.group(1) if m else None
+
+
+            results.append({
+                "brand": brand,
+                "name": name,
+                "link": "https://www.oliveyoung.co.kr" + link,
+                "image": image,
+                "raw_price": raw_price,
+                "sale_price": sale_price,
+                "score": score,
+                "review_count": review_count,
+            })
+
+        except Exception as e:
+            print("\n[LOGGING] 파싱 실패:", e)
+            print(prd)
+            continue
+
+
+    return results
+
+
+if __name__ == "__main__":
+    base_dir = "html"
+    all_products = []
+
+    for i in range(1, 17):   # 페이지 1~16
+        file_path = os.path.join(base_dir, f"page_{i}.html")
+        
+        print(f"[INFO] 페이지 {i} 로컬 HTML 파싱 중…")
+
+        with open(file_path, "r", encoding="utf-8") as f:
+            html = f.read()
+            products = extract_products_from_html(html)
+            print(f"[INFO] page_{i}: {len(products)} 개 상품 추출")
+
+        all_products.extend(products)
+
+    print(f"\n [DONE] 전체 총 상품 수: {len(all_products)}")
+
+    # 저장
+    os.makedirs("data", exist_ok=True)
+    pd.DataFrame(all_products).to_csv("data/olive_prd.csv", index=False)
+    print("CSV 저장 완료")

--- a/src/save_page.py
+++ b/src/save_page.py
@@ -1,0 +1,62 @@
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service
+from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+import time
+import os
+
+CATERORY_NO = "100000200040001"
+BASE_URL = f"https://www.oliveyoung.co.kr/store/display/getMCategoryList.do?dispCatNo={CATERORY_NO}&pageIdx={{}}"
+SAVE_DIR = "html"
+TOTAL_PAGE = 16
+
+def scroll_page(driver, times=10):
+    for i in range(times):
+        driver.find_element(By.TAG_NAME, "body").send_keys(Keys.END)
+        time.sleep(1.2)
+
+def save_rendered_html(page_no):
+    url = BASE_URL.format(page_no)
+
+    print(f"[INFO] 페이지 {page_no} 접속 중: {url}")
+
+    driver.get(url)
+    time.sleep(2.5)
+
+    scroll_page(driver, times=12)
+
+    html = driver.page_source
+
+    os.makedirs(SAVE_DIR, exist_ok=True)
+    path = f"{SAVE_DIR}/page_{page_no}.html"
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(html)
+
+    print(f"[INFO] 저장 완료 → {path}")
+
+
+if __name__ == "__main__":
+    options = webdriver.ChromeOptions()
+
+    # 유저 에이전트 넣어서 Cloudflare 우회
+    options.add_argument("user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36")
+
+    # 브라우저 안 띄우고 실행
+    options.add_argument("--headless=new")
+    options.add_argument("--disable-gpu")
+    options.add_argument("--window-size=1920,1080")
+
+    driver = webdriver.Chrome(
+        service=Service(ChromeDriverManager().install()),
+        options=options
+    )
+
+    # Cloudflare bot detection 우회
+    driver.execute_script("Object.defineProperty(navigator, 'webdriver', {get: () => undefined})")
+
+    for page in range(1, TOTAL_PAGE + 1):
+        save_rendered_html(page)
+
+    driver.quit()


### PR DESCRIPTION
### 관련 이슈
- closed #1 

### 구현 내용
- cloudflare, bot detection 정책 때문에 직접적인 상품 API/HTML 렌더링을 차단시켜서 직접 페이지에 대한 Html을 직접 저장해서 로컬로 파싱하는 방식으로 구현
- 이를 `src/html`에 `page_{num}.html`로 저장함
- 올리브영의 카테고리는 각각 고유번호를 가지고 있음. 이를 사용해 `save_page.py`를 모든 카테고리에 대해 재사용 가능함
- 전체 페이지 수는 두 파일 모두 하드코딩이 필요함